### PR TITLE
Including kernel series 3.2.

### DIFF
--- a/GobiSerial/GobiSerial.c
+++ b/GobiSerial/GobiSerial.c
@@ -49,7 +49,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <linux/usb.h>
 #include <linux/usb/serial.h>
 #include <linux/version.h>
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION( 3,3,0 ))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION( 3,2,0 ))
 #include <linux/module.h>
 #endif
 


### PR DESCRIPTION
The module works well on 3.2 kernels (current Ubuntu 12.04 LTS kernel).

```
$ uname -a
Linux anonymous 3.2.0-57-generic #87-Ubuntu SMP Tue Nov 12 21:35:10 UTC 2013 x86_64 x86_64 x86_64 GNU/Linux
$ ifconfig eth1
eth1      Link encap:Ethernet  HWaddr 00:11:22:33:44:55
          inet addr:192.168.1.4  Bcast:192.168.1.255  Mask:255.255.255.0
          inet6 addr: fe80::9c81:6eff:3211:108/64 Scope:Link
          UP BROADCAST RUNNING NOARP MULTICAST  MTU:1500  Metric:1
          RX packets:8156 errors:0 dropped:0 overruns:0 frame:0
          TX packets:7240 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000 
          RX bytes:6743673 (6.7 MB)  TX bytes:1191920 (1.1 MB)

```
