### PR TITLE
Revert "Added Support for NetGear AirCard 340U and 341U"

### DIFF
--- a/GobiSerial/GobiSerial.c
+++ b/GobiSerial/GobiSerial.c
@@ -159,8 +159,6 @@ static struct usb_device_id GobiVIDPIDTable[] =
    { USB_DEVICE( 0x03f0, 0x371d ) },   // Gobi 3000 HP un2430 Device
    { USB_DEVICE( 0x1410, 0xa021 ) },   // Novatel Wireless E396 - Gobi VID/PID
    { USB_DEVICE( 0x1410, 0xa023 ) },   // Novatel Wireless E346 - Gobi VID/PID
-   { USB_DEVICE( 0x1199, 0x9051 ) },   // NetGear AirCard 340U
-   { USB_DEVICE( 0x1199, 0x9055 ) },   // NetGear Aircard 341U
    { }                               // Terminating entry
 };
 MODULE_DEVICE_TABLE( usb, GobiVIDPIDTable );


### PR DESCRIPTION
Reverts casastorta/gobiserial#4, as we discussed in that issue. Once you've taken a look at the wiki/gist changes, naturally. :)
